### PR TITLE
Adding streambuffer and iostream

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ if _, err := stream.WriteAt([]byte("1234"), 0); err != nil {
 ```golang
 // Write the contents of S3 Object to a writer (just using a buffer in this case but could be any streaming writer)
 writer := new(bytes.Buffer)
-// Create a buffer with at least the number of concurreny downloader goroutines that will be running.
-// Although ideally ideally we even add a few more so that if one of the first few downloads gets stalled other goroutines
+// Create a buffer with at least the number of concurrent downloader goroutines that will be running.
+// Although ideally we even add a few more so that if one of the first few downloads gets stalled other goroutines
 // can continue making progress.
 // The internal buffer size will end up being numBuffers * bufferSize.
-numBuffers := s3manager.DefaultDownloadConcurrency + 3
 bufferSize := s3manager.DefaultDownloadPartSize
-stream := iostream.OpenWriterAtStream(writer, numBuffers, bufferSize)
+numBuffers := s3manager.DefaultDownloadConcurrency + 3
+stream := iostream.OpenWriterAtStream(writer, bufferSize, numBuffers)
 defer stream.Close()
-n, err := downloader.Download(f, &s3.GetObjectInput{
+n, err := downloader.Download(stream, &s3.GetObjectInput{
     Bucket: aws.String(myBucket),
     Key:    aws.String(myString),
 })

--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
-# iostream is a golang package to help with streaming coversions
+# iostream
 
-Primary goal for now is converting an io.WriterAt to an io.Writer
+iostream is a golang library meant for converting between streaming interfaces.
+
+The primary goal of iostream for now is converting an io.WriterAt to an io.Writer as long as the WriterAt has a predictable pattern of spawning multiple goroutines that are try to fill out the file from the start. This was primarily built as a way to use the [AWS s3 download manager](https://godoc.org/github.com/aws/aws-sdk-go/service/s3#hdr-Download_Manager) to write to an `io.Writer` instead of an `io.WriterAt` which usually requires either a full file or a full buffer.
+
+## Usage
+
+### OpenWriterAtStream
+```golang
+writer := new(bytes.Buffer)
+stream := iostream.OpenWriterAtStream(writer, 2, 2)
+defer stream.Close()
+if _, err := stream.WriteAt([]byte("1234"), 0); err != nil {
+	panic(err)
+}
+```
+
+### Using with aws s3 [download manager](https://godoc.org/github.com/aws/aws-sdk-go/service/s3#hdr-Download_Manager)
+```golang
+// Write the contents of S3 Object to a writer (just using a buffer in this case but could be any streaming writer)
+writer := new(bytes.Buffer)
+// Create a buffer with at least the number of concurreny downloader goroutines that will be running.
+// Although ideally ideally we even add a few more so that if one of the first few downloads gets stalled other goroutines
+// can continue making progress.
+// The internal buffer size will end up being numBuffers * bufferSize.
+numBuffers := s3manager.DefaultDownloadConcurrency + 3
+bufferSize := s3manager.DefaultDownloadPartSize
+stream := iostream.OpenWriterAtStream(writer, numBuffers, bufferSize)
+defer stream.Close()
+n, err := downloader.Download(f, &s3.GetObjectInput{
+    Bucket: aws.String(myBucket),
+    Key:    aws.String(myString),
+})
+if err != nil {
+    return fmt.Errorf("failed to download file, %v", err)
+}
+```
+
+See the [tests](iostream_test.go) for more usage examples

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/PullRequestInc/iostream
+
+go 1.13
+
+require github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/PullRequestInc/cmn v0.0.0-20191009172016-66afda037d66 h1:nl99+J7+yJ2Eezq4OKrh+oe6YxJDcZE88LE5Lf1StbU=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/iostream.go
+++ b/iostream.go
@@ -1,0 +1,127 @@
+package iostream
+
+import (
+	"errors"
+	"io"
+)
+
+// WriterAtStream is meant to convert an io.WriterAt to an io.Writer using an in memory buffer.
+// It will use mutliple buffers, but prevent letting the entire file being written in memory.
+// It should only be used if there is a guarantee that the next chunk of bytes that the writer
+// needs will eventually be passed if WriteAt is blocking for other writes further in the stream.
+// The io.WriterAt should also only attempt to a chunk of bytes once, as once a chunk has been
+// written, it is assumed that the buffer's offset can advance.
+type WriterAtStream struct {
+	buffer    *StreamBuffer
+	writer    io.Writer
+	newChunks chan *byteChunk
+	closed    chan int // signalled when Close is called
+	done      chan int // signalled after close has been completed
+}
+
+// OpenWriterAtStream opened a WriterAtStream. The stream should be closed by the caller to clean up
+// resources. If an error occurs, all subsequent WriteAts will begin to error out.
+func OpenWriterAtStream(writer io.Writer, bufferSize, numBuffers int) *WriterAtStream {
+	stream := &WriterAtStream{
+		buffer:    NewStreamBuffer(numBuffers, bufferSize),
+		writer:    writer,
+		newChunks: make(chan *byteChunk),
+		closed:    make(chan int),
+		done:      make(chan int),
+	}
+	go stream.start()
+	return stream
+}
+
+type byteChunk struct {
+	bytes    []byte
+	offset   int64
+	response chan *writeAtResp
+}
+
+type writeAtResp struct {
+	err error
+}
+
+func (s *WriterAtStream) start() {
+	// backedUp holds byteChunks that are beyond our buffer and are currently being blocked
+	// until the buffer grows to accomodate them as a backpressure mechanism.
+	var backedUp []*byteChunk
+
+	for {
+		select {
+		case <-s.closed:
+			closedErr := errors.New("WriterAtStream Closed")
+
+			close(s.newChunks)
+
+			for chunk := range s.newChunks {
+				chunk.response <- &writeAtResp{
+					err: closedErr,
+				}
+			}
+			for _, chunk := range backedUp {
+				chunk.response <- &writeAtResp{
+					err: closedErr,
+				}
+			}
+
+			close(s.done)
+			return
+		case chunk := <-s.newChunks:
+			var err error
+			_, err = s.buffer.WriteAt(chunk.bytes, chunk.offset)
+			if err == ErrAfterBounds {
+				// this chunk is too far ahead, we need to block it being written for now
+				backedUp = append(backedUp, chunk)
+				continue
+			}
+
+			for {
+				toWrite := s.buffer.Flush()
+				if len(toWrite) == 0 {
+					break
+				}
+				if _, err = s.writer.Write(toWrite); err != nil {
+					break
+				}
+				var newBackedUp []*byteChunk
+				for _, chunk := range backedUp {
+					if _, err = s.buffer.WriteAt(chunk.bytes, chunk.offset); err != nil {
+						if err == ErrAfterBounds {
+							newBackedUp = append(newBackedUp, chunk)
+							err = nil
+						} else {
+							break
+						}
+					}
+				}
+				backedUp = newBackedUp
+			}
+
+			chunk.response <- &writeAtResp{err}
+		}
+	}
+}
+
+// Close must be called to cleanup resources and finish flushing data to writer
+func (s *WriterAtStream) Close() {
+	close(s.closed)
+	<-s.done
+}
+
+// WriteAt implements the io.WriterAt interface
+func (s *WriterAtStream) WriteAt(p []byte, off int64) (n int, err error) {
+	response := make(chan *writeAtResp)
+	defer close(response)
+
+	chunk := &byteChunk{
+		bytes:    p,
+		offset:   off,
+		response: response,
+	}
+	s.newChunks <- chunk
+
+	r := <-response
+	return len(p), r.err
+}

--- a/iostream.go
+++ b/iostream.go
@@ -9,8 +9,8 @@ import (
 // It will use mutliple buffers, but prevent letting the entire file being written in memory.
 // It should only be used if there is a guarantee that the next chunk of bytes that the writer
 // needs will eventually be passed if WriteAt is blocking for other writes further in the stream.
-// The io.WriterAt should also only attempt to a chunk of bytes once, as once a chunk has been
-// written, it is assumed that the buffer's offset can advance.
+// The io.WriterAt should also only attempt to write a chunk of bytes once, as once a chunk has
+// been written, it is assumed that the buffer's offset can advance.
 type WriterAtStream struct {
 	buffer    *StreamBuffer
 	writer    io.Writer

--- a/iostream_test.go
+++ b/iostream_test.go
@@ -18,8 +18,6 @@ func TestSingleChunkSingleBuffer(t *testing.T) {
 	stream.Close()
 	require.NoError(t, err)
 	require.Equal(t, 4, written)
-
-	require.NoError(t, err)
 	require.Equal(t, "1234", buf.String())
 }
 
@@ -34,7 +32,6 @@ func TestMultipleChunksSingleBuffer(t *testing.T) {
 
 	stream.Close()
 
-	require.NoError(t, err)
 	require.Equal(t, "1234", buf.String())
 }
 
@@ -56,7 +53,6 @@ func TestMultipleChunksWithBlockedChunksBeyondBuffer(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		stream.WriteAt([]byte("far away"), 100)
-		// require.NoError(t, err)
 		cleanedUp = true
 		wg.Done()
 	}()
@@ -81,6 +77,5 @@ func TestMultipleChunksWithBlockedChunksBeyondBuffer(t *testing.T) {
 
 	require.True(t, cleanedUp)
 
-	require.NoError(t, err)
 	require.Equal(t, "1234567890123456", buf.String())
 }

--- a/iostream_test.go
+++ b/iostream_test.go
@@ -1,0 +1,86 @@
+package iostream_test
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/PullRequestInc/iostream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleChunkSingleBuffer(t *testing.T) {
+	buf := new(bytes.Buffer)
+	stream := iostream.OpenWriterAtStream(buf, 4, 2)
+
+	written, err := stream.WriteAt([]byte("1234"), 0)
+	stream.Close()
+	require.NoError(t, err)
+	require.Equal(t, 4, written)
+
+	require.NoError(t, err)
+	require.Equal(t, "1234", buf.String())
+}
+
+func TestMultipleChunksSingleBuffer(t *testing.T) {
+	buf := new(bytes.Buffer)
+	stream := iostream.OpenWriterAtStream(buf, 4, 2)
+
+	_, err := stream.WriteAt([]byte("12"), 0)
+	require.NoError(t, err)
+	_, err = stream.WriteAt([]byte("34"), 2)
+	require.NoError(t, err)
+
+	stream.Close()
+
+	require.NoError(t, err)
+	require.Equal(t, "1234", buf.String())
+}
+
+func TestMultipleChunksWithBlockedChunksBeyondBuffer(t *testing.T) {
+	buf := new(bytes.Buffer)
+	stream := iostream.OpenWriterAtStream(buf, 4, 2)
+
+	// this write should get blocked so do it on a separate goroutine
+	go func() {
+		_, err := stream.WriteAt([]byte("90123456"), 8)
+		require.NoError(t, err)
+	}()
+
+	// this write should get blocked so do it on a separate goroutine. it will never
+	// actually get written so we will use it to test behavior of blocked writes getting
+	// unblocked by the Close()
+	cleanedUp := false
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		stream.WriteAt([]byte("far away"), 100)
+		// require.NoError(t, err)
+		cleanedUp = true
+		wg.Done()
+	}()
+
+	// give the goroutine above a second to make sure it calls before the next two and exercises
+	// the backed up blocking behavior
+	time.Sleep(1 * time.Millisecond)
+
+	_, err := stream.WriteAt([]byte("1234"), 0)
+	require.NoError(t, err)
+
+	// should only have written 1234 yet
+	require.Equal(t, "1234", buf.String())
+
+	_, err = stream.WriteAt([]byte("5678"), 4)
+	require.NoError(t, err)
+
+	require.False(t, cleanedUp)
+
+	stream.Close()
+	wg.Wait()
+
+	require.True(t, cleanedUp)
+
+	require.NoError(t, err)
+	require.Equal(t, "1234567890123456", buf.String())
+}

--- a/iostream_test.go
+++ b/iostream_test.go
@@ -51,8 +51,9 @@ func TestMultipleChunksWithBlockedChunksBeyondBuffer(t *testing.T) {
 	cleanedUp := false
 	wg := sync.WaitGroup{}
 	wg.Add(1)
+	var writeErr error
 	go func() {
-		stream.WriteAt([]byte("far away"), 100)
+		_, writeErr = stream.WriteAt([]byte("far away"), 100)
 		cleanedUp = true
 		wg.Done()
 	}()
@@ -69,6 +70,7 @@ func TestMultipleChunksWithBlockedChunksBeyondBuffer(t *testing.T) {
 
 	_, err = stream.WriteAt([]byte("5678"), 4)
 	require.NoError(t, err)
+	require.Equal(t, "1234567890123456", buf.String())
 
 	require.False(t, cleanedUp)
 
@@ -78,4 +80,6 @@ func TestMultipleChunksWithBlockedChunksBeyondBuffer(t *testing.T) {
 	require.True(t, cleanedUp)
 
 	require.Equal(t, "1234567890123456", buf.String())
+
+	require.EqualError(t, writeErr, "WriterAtStream Closed")
 }

--- a/streambuffer.go
+++ b/streambuffer.go
@@ -1,0 +1,158 @@
+package iostream
+
+import (
+	"bytes"
+	"container/ring"
+	"errors"
+	"sync"
+)
+
+type StreamBuffer struct {
+	sync.Mutex
+	bufferSize    int
+	offset        int64
+	flushedOffset int64
+	buffers       *ring.Ring
+	// map from starting offset through ending offset
+	writtenChunks map[int64]int64
+}
+
+// ErrBeforeBounds represents an attempt to WriteAt before the start of the buffer
+var ErrBeforeBounds = errors.New("WriteAt attempt is before start of buffer")
+
+// ErrAfterBounds represents an attempt to WriteAt beyond the current bounds of the buffer.
+var ErrAfterBounds = errors.New("WriteAt attempt is after end of buffer")
+
+// NewStreamBuffer creates a new StreamBuffer that has bufferCount internal
+// rotating buffers of size bufferSize.
+func NewStreamBuffer(bufferCount int, bufferSize int) *StreamBuffer {
+	// Initialize all of the buffers at once.
+	// We could eventually do this more dynamically and only initialiize new ones as needed
+	// to optimize for smaller streams.
+	buffers := ring.New(bufferCount)
+	for i := 0; i < bufferSize; i++ {
+		buffers.Value = bytes.NewBuffer(make([]byte, bufferSize))
+		buffers = buffers.Next()
+	}
+
+	return &StreamBuffer{
+		bufferSize:    bufferSize,
+		buffers:       buffers,
+		writtenChunks: map[int64]int64{},
+	}
+}
+
+// WriteAt implements io.WriterAt interface
+func (b *StreamBuffer) WriteAt(p []byte, off int64) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	b.Lock()
+	defer b.Unlock()
+
+	if off < b.offset {
+		return 0, ErrBeforeBounds
+	}
+	if off+int64(len(p)) > b.offset+int64(b.buffers.Len())*int64(b.bufferSize) {
+		return 0, ErrAfterBounds
+	}
+	normalizedOffset := off - b.offset
+	written := 0
+
+	buffers := b.buffers
+	for i := 0; i < b.buffers.Len(); i++ {
+		// if the write is beyond the current buffer then continue
+		if normalizedOffset+int64(written) > int64((i+1)*b.bufferSize) {
+			buffers = buffers.Next()
+			continue
+		}
+		// copy the portion of p bytes that fit in current buffer
+		buf := buffers.Value.(*bytes.Buffer)
+		data := buf.Bytes()
+
+		bufferStart := i * b.bufferSize
+		bufferEnd := (i + 1) * b.bufferSize
+
+		copyStart := normalizedOffset + int64(written-bufferStart)
+		copyEnd := copyStart + int64(len(p)-written)
+		if copyEnd > int64(bufferEnd) {
+			copyEnd = int64(bufferEnd - bufferStart)
+		}
+		copy(data[copyStart:copyEnd], p[written:copyEnd-copyStart+int64(written)])
+
+		written += int(copyEnd - copyStart)
+
+		if written >= len(p) {
+			break
+		}
+
+		buffers = buffers.Next()
+	}
+
+	// update state for written chunks
+	b.writtenChunks[off] = off + int64(len(p))
+
+	return written, nil
+}
+
+// Flush will flush all bytes that are fully written from the start of the internal
+// buffer. These bytes will not be returned again.
+func (b *StreamBuffer) Flush() []byte {
+	b.Lock()
+	defer b.Unlock()
+
+	normalizedFlushedOffset := b.flushedOffset - b.offset
+
+	toWrite := 0
+
+	for {
+		newOffset, ok := b.writtenChunks[b.flushedOffset]
+		if !ok {
+			break
+		}
+		toWrite += int(newOffset - b.flushedOffset)
+		delete(b.writtenChunks, b.flushedOffset)
+		b.flushedOffset = newOffset
+	}
+
+	if toWrite == 0 {
+		return nil
+	}
+
+	out := make([]byte, toWrite)
+
+	written := 0
+
+	for i := 0; i < b.buffers.Len(); i++ {
+		buf := b.buffers.Value.(*bytes.Buffer)
+		data := buf.Bytes()
+
+		bufferStart := i * b.bufferSize
+		bufferEnd := (i + 1) * b.bufferSize
+
+		bufferCopyOffset := normalizedFlushedOffset + int64(written-bufferStart)
+
+		toWriteFromBuffer := toWrite - written
+		if toWrite > bufferEnd-int(bufferCopyOffset) {
+			toWriteFromBuffer = bufferEnd - int(bufferCopyOffset)
+		}
+
+		copy(out[written:written+toWriteFromBuffer], data[bufferCopyOffset:int(bufferCopyOffset)+toWriteFromBuffer])
+
+		written += toWriteFromBuffer
+
+		// reset data in this flushed buffer and advance
+		if b.flushedOffset >= b.offset+int64(b.bufferSize) {
+			buf.Reset()
+			b.buffers = b.buffers.Next()
+			b.offset += int64(b.bufferSize)
+		}
+
+		if written >= toWrite {
+			break
+		}
+	}
+
+	return out
+}

--- a/streambuffer_test.go
+++ b/streambuffer_test.go
@@ -1,0 +1,138 @@
+package iostream_test
+
+import (
+	"testing"
+
+	"github.com/PullRequestInc/iostream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlushingEmpty(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	require.Len(t, sb.Flush(), 0)
+}
+
+func TestWritingEmpty(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	written, err := sb.WriteAt(nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, 0, written)
+	require.Len(t, sb.Flush(), 0)
+}
+
+func TestWritingBeforeBounds(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	_, err := sb.WriteAt([]byte("a"), -1)
+	require.Equal(t, iostream.ErrBeforeBounds, err)
+}
+
+func TestWritingAfterBounds(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	_, err := sb.WriteAt([]byte("a"), 4)
+	require.Equal(t, iostream.ErrAfterBounds, err)
+}
+
+func TestWritingOnceOnFirstBuffer(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	written, err := sb.WriteAt([]byte("a"), 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, written)
+	require.Equal(t, "a", string(sb.Flush()))
+	require.Equal(t, "", string(sb.Flush()))
+}
+
+func TestWritingTwiceOnFirstBuffer(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	written, err := sb.WriteAt([]byte("a"), 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, written)
+	require.Equal(t, "a", string(sb.Flush()))
+	written, err = sb.WriteAt([]byte("b"), 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, written)
+	require.Equal(t, "b", string(sb.Flush()))
+	require.Equal(t, "", string(sb.Flush()))
+}
+
+func TestWritingTwiceOnFirstBufferBeforeFlush(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	written, err := sb.WriteAt([]byte("a"), 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, written)
+	written, err = sb.WriteAt([]byte("b"), 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, written)
+	require.Equal(t, "ab", string(sb.Flush()))
+	require.Equal(t, "", string(sb.Flush()))
+}
+
+func TestWritingOnceAcrossTwoBuffers(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	written, err := sb.WriteAt([]byte("abc"), 0)
+	require.NoError(t, err)
+	require.Equal(t, 3, written)
+	require.Equal(t, "abc", string(sb.Flush()))
+	require.Equal(t, "", string(sb.Flush()))
+}
+
+func TestWritingTwiceAcrossTwoBuffersInOrder(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	written, err := sb.WriteAt([]byte("ab"), 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, written)
+	require.Equal(t, "ab", string(sb.Flush()))
+	written, err = sb.WriteAt([]byte("cd"), 2)
+	require.NoError(t, err)
+	require.Equal(t, 2, written)
+	require.Equal(t, "cd", string(sb.Flush()))
+	require.Equal(t, "", string(sb.Flush()))
+}
+
+func TestWritingTwiceAcrossTwoBuffersOutOfOrder(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	written, err := sb.WriteAt([]byte("cd"), 2)
+	require.NoError(t, err)
+	require.Equal(t, 2, written)
+	require.Equal(t, "", string(sb.Flush()))
+	written, err = sb.WriteAt([]byte("ab"), 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, written)
+	require.Equal(t, "abcd", string(sb.Flush()))
+	require.Equal(t, "", string(sb.Flush()))
+}
+
+func TestWritingOnRotatedBuffer(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	written, err := sb.WriteAt([]byte("abcd"), 0)
+	require.NoError(t, err)
+	require.Equal(t, 4, written)
+	require.Equal(t, "abcd", string(sb.Flush()))
+	written, err = sb.WriteAt([]byte("efgh"), 4)
+	require.NoError(t, err)
+	require.Equal(t, 4, written)
+	require.Equal(t, "efgh", string(sb.Flush()))
+	require.Equal(t, "", string(sb.Flush()))
+}
+
+func TestLotsOfWritesInVariousOrders(t *testing.T) {
+	sb := iostream.NewStreamBuffer(2, 2)
+	written, err := sb.WriteAt([]byte("c"), 2)
+	require.NoError(t, err)
+	require.Equal(t, 1, written)
+	require.Equal(t, "", string(sb.Flush()))
+	written, err = sb.WriteAt([]byte("a"), 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, written)
+	require.Equal(t, "a", string(sb.Flush()))
+	written, err = sb.WriteAt([]byte("b"), 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, written)
+	written, err = sb.WriteAt([]byte("d"), 3)
+	require.NoError(t, err)
+	require.Equal(t, 1, written)
+	require.Equal(t, "bcd", string(sb.Flush()))
+	written, err = sb.WriteAt([]byte("efgh"), 4)
+	require.NoError(t, err)
+	require.Equal(t, 4, written)
+	require.Equal(t, "efgh", string(sb.Flush()))
+}


### PR DESCRIPTION
This is a new repo/package that I am creating as a way to stream an `io.WriterAt` as an `io.Writer` using an in memory buffer. Otherwise the only built in ways to do this that I have been able to find would be using a file or buffer that is the size of the entire data being streamed. There is more explanation/example usage in the README.