### PR TITLE
Fix offsets and document streambuffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: vet
+vet:
+	go vet ./...
+
+.PHONY: build
+build:
+	go build ./...
+
+.PHONY: test
+test:
+	go test ./...
+
+.PHONY: check
+check: vet build test

--- a/iostream.go
+++ b/iostream.go
@@ -46,6 +46,7 @@ type writeAtResp struct {
 func (s *WriterAtStream) start() {
 	// backedUp holds byteChunks that are beyond our buffer and are currently being blocked
 	// until the buffer grows to accomodate them as a backpressure mechanism.
+	// TODO: Use linked list?
 	var backedUp []*byteChunk
 
 	for {

--- a/streambuffer_test.go
+++ b/streambuffer_test.go
@@ -101,6 +101,18 @@ func TestWritingTwiceAcrossTwoBuffersOutOfOrder(t *testing.T) {
 	require.Equal(t, "", string(sb.Flush()))
 }
 
+func TestBufferedWriteTwiceAcrossTwoBuffersInOrderPastSecond(t *testing.T) {
+	sb := iostream.NewStreamBuffer(3, 2)
+	written, err := sb.WriteAt([]byte("ab"), 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, written)
+	written, err = sb.WriteAt([]byte("cde"), 2)
+	require.NoError(t, err)
+	require.Equal(t, 3, written)
+	require.Equal(t, "abcde", string(sb.Flush()))
+	require.Equal(t, "", string(sb.Flush()))
+}
+
 func TestWritingOnRotatedBuffer(t *testing.T) {
 	sb := iostream.NewStreamBuffer(2, 2)
 	written, err := sb.WriteAt([]byte("abcd"), 0)


### PR DESCRIPTION
- The issue I was hitting was the upper boundary of the slice I was
  copying into was trending larger than the slice itself, so I went back
  through the streambuffer file line-by-line and documented it so that I
  understand it better.
- In addition, I also tracked down and fixed the issue in the
  calculation of the copyEnd value. Before, we were checking if it was
  greater than bufferEnd, but bufferEnd was the incorrect value to use.
  Rather, ensure it's less than b.bufferSize, which will always be
  correct.
- I also ensured the Flush function mirrored the WriteAt function in
  terms of calculating offsets so that we don't have to get at the
  numbers from different directions. For all I know, I fixed something
  there too as I didn't trace the original logic - just rewrote it.