### PR TITLE
Use simplified nonblocking variant of iostream

### DIFF
--- a/bufpool.go
+++ b/bufpool.go
@@ -1,0 +1,37 @@
+package iostream
+
+import (
+	"bytes"
+	"sync"
+)
+
+// BufPool is a sync.Pool with bytes.Buffer typings
+type BufPool interface {
+	Get() *bytes.Buffer
+	Put(*bytes.Buffer)
+}
+
+type bufPool struct {
+	pool *sync.Pool
+}
+
+// NewBufPool creates a new BufPool
+func NewBufPool(bytesPerBuffer int) BufPool {
+	pool := &sync.Pool{
+		New: func() interface{} {
+			buf := make([]byte, bytesPerBuffer)
+			return bytes.NewBuffer(buf)
+		},
+	}
+	return &bufPool{
+		pool: pool,
+	}
+}
+
+func (p *bufPool) Get() *bytes.Buffer {
+	return p.pool.Get().(*bytes.Buffer)
+}
+
+func (p *bufPool) Put(buf *bytes.Buffer) {
+	p.pool.Put(buf)
+}

--- a/bufpool.go
+++ b/bufpool.go
@@ -33,5 +33,6 @@ func (p *bufPool) Get() *bytes.Buffer {
 }
 
 func (p *bufPool) Put(buf *bytes.Buffer) {
+	buf.Reset()
 	p.pool.Put(buf)
 }

--- a/bufpool.go
+++ b/bufpool.go
@@ -19,7 +19,7 @@ type bufPool struct {
 func NewBufPool(bytesPerBuffer int) BufPool {
 	pool := &sync.Pool{
 		New: func() interface{} {
-			buf := make([]byte, bytesPerBuffer)
+			buf := make([]byte, 0, bytesPerBuffer)
 			return bytes.NewBuffer(buf)
 		},
 	}

--- a/bufpool_test.go
+++ b/bufpool_test.go
@@ -1,0 +1,33 @@
+package iostream_test
+
+import (
+	"testing"
+
+	"github.com/PullRequestInc/iostream"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBufPool(t *testing.T) {
+	pool := iostream.NewBufPool(100)
+	// get a couple of buffers to test
+	buf := pool.Get()
+	assert.Equal(t, 100, buf.Cap())
+	assert.Equal(t, 0, buf.Len())
+	buf = pool.Get()
+	assert.Equal(t, 100, buf.Cap())
+	assert.Equal(t, 0, buf.Len())
+
+	_, err := buf.WriteString("abc")
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", buf.String())
+	assert.Equal(t, 100, buf.Cap())
+	assert.Equal(t, 3, buf.Len())
+
+	pool.Put(buf)
+	assert.Equal(t, 100, buf.Cap())
+	assert.Equal(t, 0, buf.Len())
+
+	buf = pool.Get()
+	assert.Equal(t, 100, buf.Cap())
+	assert.Equal(t, 0, buf.Len())
+}

--- a/iostream.go
+++ b/iostream.go
@@ -1,8 +1,13 @@
 package iostream
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"io"
+	"sort"
+	"sync"
+	"time"
 )
 
 // WriterAtStream is meant to convert an io.WriterAt to an io.Writer using an in memory buffer.
@@ -12,22 +17,30 @@ import (
 // The io.WriterAt should also only attempt to write a chunk of bytes once, as once a chunk has
 // been written, it is assumed that the buffer's offset can advance.
 type WriterAtStream struct {
-	buffer    *StreamBuffer
-	writer    io.Writer
-	newChunks chan *byteChunk
-	closed    chan int // signalled when Close is called
-	done      chan int // signalled after close has been completed
+	bufferPool        BufPool
+	writer            io.Writer
+	newChunks         chan *byteChunk
+	closed            chan int // signalled when Close is called
+	done              chan int // signalled after close has been completed
+	bufferSize        int
+	numBuffers        int
+	err               error
+	lastWrittenOffset int64
+	offsetLock        *sync.RWMutex
 }
 
 // OpenWriterAtStream opened a WriterAtStream. The stream should be closed by the caller to clean up
 // resources. If an error occurs, all subsequent WriteAts will begin to error out.
-func OpenWriterAtStream(writer io.Writer, bufferSize, numBuffers int) *WriterAtStream {
+func OpenWriterAtStream(writer io.Writer, bufferPool BufPool, numBuffers, bufferSize int) *WriterAtStream {
 	stream := &WriterAtStream{
-		buffer:    NewStreamBuffer(numBuffers, bufferSize),
-		writer:    writer,
-		newChunks: make(chan *byteChunk),
-		closed:    make(chan int),
-		done:      make(chan int),
+		bufferPool: bufferPool,
+		writer:     writer,
+		newChunks:  make(chan *byteChunk),
+		closed:     make(chan int),
+		done:       make(chan int),
+		bufferSize: bufferSize,
+		numBuffers: numBuffers,
+		offsetLock: new(sync.RWMutex),
 	}
 	go stream.start()
 	return stream
@@ -39,8 +52,52 @@ type byteChunk struct {
 	response chan *writeAtResp
 }
 
+type toWriteChunk struct {
+	buf    *bytes.Buffer
+	offset int64
+}
+
+type wroteChunk struct {
+	buf    *bytes.Buffer
+	offset int64
+	err    error
+}
+
 type writeAtResp struct {
 	err error
+}
+
+func (s *WriterAtStream) writeChunkIfNeeded(doneWriting chan *wroteChunk, chunk *toWriteChunk) (successfullyWrote bool) {
+	// if this is the first block, or the next block that we are supposed to write, then go ahead and write it
+	if s.lastWrittenOffset == 0 && chunk.offset == 0 || s.lastWrittenOffset == chunk.offset-int64(s.bufferSize) {
+		var written int
+		toWriteBytes := chunk.buf.Bytes()
+		for len(toWriteBytes) > written {
+			w, err := s.writer.Write(toWriteBytes)
+			if err != nil {
+				wrote := &wroteChunk{
+					buf: chunk.buf,
+					err: err,
+				}
+				doneWriting <- wrote
+				return false
+			}
+			written += w
+		}
+
+		// update the last written offset
+		s.offsetLock.Lock()
+		s.lastWrittenOffset = chunk.offset
+		s.offsetLock.Unlock()
+
+		// notify done writing without errors
+		wrote := &wroteChunk{
+			buf: chunk.buf,
+		}
+		doneWriting <- wrote
+		return true
+	}
+	return false
 }
 
 func (s *WriterAtStream) start() {
@@ -49,11 +106,77 @@ func (s *WriterAtStream) start() {
 	// TODO: Use linked list?
 	var backedUp []*byteChunk
 
+	toWrite := make(chan *toWriteChunk, s.numBuffers)
+	doneWriting := make(chan *wroteChunk, s.numBuffers)
+
+	// spin off a writer worker thread
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		var pendingWrites []*toWriteChunk
+
+		for {
+			select {
+			case chunk := <-toWrite:
+				if chunk == nil {
+					// done/channel closed
+					return
+				}
+
+				successfullyWrote := s.writeChunkIfNeeded(doneWriting, chunk)
+				if !successfullyWrote {
+					// add this chunk to the pendingWrites if we weren't able to write it yet and we'll try again
+					// later after a write succeeds.
+					pendingWrites = append(pendingWrites, chunk)
+
+					// TODO: would be potentially faster with a min heap but I'm lazy and there are only going to
+					// be small number of items in here (should be less than or equal to numBuffers)
+					sort.SliceStable(pendingWrites, func(i, j int) bool {
+						return pendingWrites[i].offset < pendingWrites[j].offset
+					})
+					break
+				}
+
+				// if we successfully wrote, then lets try the pending chunks
+				var removedOffsets map[int64]bool
+				for _, c := range pendingWrites {
+					successfullyWrote := s.writeChunkIfNeeded(doneWriting, c)
+					if !successfullyWrote {
+						break
+					}
+					removedOffsets[c.offset] = true
+				}
+
+				// remove the pending chunks that we successfully processed
+				newPendingWrites := make([]*toWriteChunk, 0, len(pendingWrites)-len(removedOffsets))
+				for _, c := range pendingWrites {
+					if removedOffsets[c.offset] {
+						continue
+					}
+					newPendingWrites = append(pendingWrites, c)
+				}
+				pendingWrites = newPendingWrites
+			}
+		}
+	}()
+
+	var latestChunk *byteChunk
+	var chunksBeingWritten int
+
 	for {
 		select {
 		case <-s.closed:
 			closedErr := errors.New("WriterAtStream Closed")
+			// set the error in case any more writes try to come in
+			s.err = closedErr
+			close(toWrite)
 
+			// wait for the writer to complete
+			wg.Wait()
+
+			close(doneWriting)
 			close(s.newChunks)
 
 			for chunk := range s.newChunks {
@@ -70,37 +193,32 @@ func (s *WriterAtStream) start() {
 			close(s.done)
 			return
 		case chunk := <-s.newChunks:
-			var err error
-			_, err = s.buffer.WriteAt(chunk.bytes, chunk.offset)
-			if err == ErrAfterBounds {
-				// this chunk is too far ahead, we need to block it being written for now
-				backedUp = append(backedUp, chunk)
-				continue
+			// copy to internal buffer
+			buf := s.bufferPool.Get()
+			copy(buf.Bytes(), chunk.bytes)
+
+			// since we have a new chunk, we can unblock the previous latest one. this is mainly
+			// just to prevent all of the WriteAts from continuing before the last write has occurred.
+			if latestChunk != nil {
+				latestChunk.response <- &writeAtResp{}
+				latestChunk = chunk
 			}
 
-			for {
-				toWrite := s.buffer.Flush()
-				if len(toWrite) == 0 {
-					break
-				}
-				if _, err = s.writer.Write(toWrite); err != nil {
-					break
-				}
-				var newBackedUp []*byteChunk
-				for _, chunk := range backedUp {
-					if _, err = s.buffer.WriteAt(chunk.bytes, chunk.offset); err != nil {
-						if err == ErrAfterBounds {
-							newBackedUp = append(newBackedUp, chunk)
-							err = nil
-						} else {
-							break
-						}
-					}
-				}
-				backedUp = newBackedUp
-			}
+			chunksBeingWritten++
 
-			chunk.response <- &writeAtResp{err}
+			writeChunk := &toWriteChunk{
+				buf:    buf,
+				offset: chunk.offset,
+			}
+			toWrite <- writeChunk
+		case chunk := <-doneWriting:
+			chunksBeingWritten--
+			s.bufferPool.Put(chunk.buf)
+			if latestChunk != nil && chunksBeingWritten == 0 {
+				// finished writing the latest chunk, unblock the write on it
+				latestChunk.response <- &writeAtResp{}
+				latestChunk = nil
+			}
 		}
 	}
 }
@@ -113,6 +231,33 @@ func (s *WriterAtStream) Close() {
 
 // WriteAt implements the io.WriterAt interface
 func (s *WriterAtStream) WriteAt(p []byte, off int64) (n int, err error) {
+	if off%int64(s.bufferSize) != 0 {
+		// this this writerAtStream expects to only received blocks of exactly the buffersize
+		// due to optimizations in the implementation.
+		return 0, fmt.Errorf("unexpected offset %q not multiple of %q", off, s.bufferSize)
+	}
+
+	for {
+		if s.err != nil {
+			return 0, s.err
+		}
+
+		s.offsetLock.RLock()
+		lastWrittenOffset := s.lastWrittenOffset
+		s.offsetLock.RUnlock()
+
+		// if we are attempting to write too far ahead in the buffer, then block and try again in a bit.
+		// this will put backpressure on threads that are too far ahead for our "streaming buffer".
+		allowedOffsetRange := s.bufferSize * s.bufferSize
+		if off > lastWrittenOffset+int64(allowedOffsetRange) {
+			time.Sleep(time.Nanosecond * 10)
+			continue
+		}
+		break
+	}
+
+	// we're good to try and write
+
 	response := make(chan *writeAtResp)
 	defer close(response)
 
@@ -123,6 +268,7 @@ func (s *WriterAtStream) WriteAt(p []byte, off int64) (n int, err error) {
 	}
 	s.newChunks <- chunk
 
+	// this response will block until either this write is completed or another write comes in after this one
 	r := <-response
 	return len(p), r.err
 }

--- a/iostream.go
+++ b/iostream.go
@@ -1,13 +1,8 @@
 package iostream
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
 	"io"
-	"sort"
-	"sync"
-	"time"
 )
 
 // WriterAtStream is meant to convert an io.WriterAt to an io.Writer using an in memory buffer.
@@ -17,30 +12,22 @@ import (
 // The io.WriterAt should also only attempt to write a chunk of bytes once, as once a chunk has
 // been written, it is assumed that the buffer's offset can advance.
 type WriterAtStream struct {
-	bufferPool        BufPool
-	writer            io.Writer
-	newChunks         chan *byteChunk
-	closed            chan int // signalled when Close is called
-	done              chan int // signalled after close has been completed
-	bufferSize        int
-	numBuffers        int
-	err               error
-	lastWrittenOffset int64
-	offsetLock        *sync.RWMutex
+	buffer    *StreamBuffer
+	writer    io.Writer
+	newChunks chan *byteChunk
+	closed    chan int // signalled when Close is called
+	done      chan int // signalled after close has been completed
 }
 
 // OpenWriterAtStream opened a WriterAtStream. The stream should be closed by the caller to clean up
 // resources. If an error occurs, all subsequent WriteAts will begin to error out.
-func OpenWriterAtStream(writer io.Writer, bufferPool BufPool, numBuffers, bufferSize int) *WriterAtStream {
+func OpenWriterAtStream(writer io.Writer, bufferSize, numBuffers int) *WriterAtStream {
 	stream := &WriterAtStream{
-		bufferPool: bufferPool,
-		writer:     writer,
-		newChunks:  make(chan *byteChunk),
-		closed:     make(chan int),
-		done:       make(chan int),
-		bufferSize: bufferSize,
-		numBuffers: numBuffers,
-		offsetLock: new(sync.RWMutex),
+		buffer:    NewStreamBuffer(numBuffers, bufferSize),
+		writer:    writer,
+		newChunks: make(chan *byteChunk),
+		closed:    make(chan int),
+		done:      make(chan int),
 	}
 	go stream.start()
 	return stream
@@ -52,52 +39,8 @@ type byteChunk struct {
 	response chan *writeAtResp
 }
 
-type toWriteChunk struct {
-	buf    *bytes.Buffer
-	offset int64
-}
-
-type wroteChunk struct {
-	buf    *bytes.Buffer
-	offset int64
-	err    error
-}
-
 type writeAtResp struct {
 	err error
-}
-
-func (s *WriterAtStream) writeChunkIfNeeded(doneWriting chan *wroteChunk, chunk *toWriteChunk) (successfullyWrote bool) {
-	// if this is the first block, or the next block that we are supposed to write, then go ahead and write it
-	if s.lastWrittenOffset == 0 && chunk.offset == 0 || s.lastWrittenOffset == chunk.offset-int64(s.bufferSize) {
-		var written int
-		toWriteBytes := chunk.buf.Bytes()
-		for len(toWriteBytes) > written {
-			w, err := s.writer.Write(toWriteBytes)
-			if err != nil {
-				wrote := &wroteChunk{
-					buf: chunk.buf,
-					err: err,
-				}
-				doneWriting <- wrote
-				return false
-			}
-			written += w
-		}
-
-		// update the last written offset
-		s.offsetLock.Lock()
-		s.lastWrittenOffset = chunk.offset
-		s.offsetLock.Unlock()
-
-		// notify done writing without errors
-		wrote := &wroteChunk{
-			buf: chunk.buf,
-		}
-		doneWriting <- wrote
-		return true
-	}
-	return false
 }
 
 func (s *WriterAtStream) start() {
@@ -106,77 +49,11 @@ func (s *WriterAtStream) start() {
 	// TODO: Use linked list?
 	var backedUp []*byteChunk
 
-	toWrite := make(chan *toWriteChunk, s.numBuffers)
-	doneWriting := make(chan *wroteChunk, s.numBuffers)
-
-	// spin off a writer worker thread
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		var pendingWrites []*toWriteChunk
-
-		for {
-			select {
-			case chunk := <-toWrite:
-				if chunk == nil {
-					// done/channel closed
-					return
-				}
-
-				successfullyWrote := s.writeChunkIfNeeded(doneWriting, chunk)
-				if !successfullyWrote {
-					// add this chunk to the pendingWrites if we weren't able to write it yet and we'll try again
-					// later after a write succeeds.
-					pendingWrites = append(pendingWrites, chunk)
-
-					// TODO: would be potentially faster with a min heap but I'm lazy and there are only going to
-					// be small number of items in here (should be less than or equal to numBuffers)
-					sort.SliceStable(pendingWrites, func(i, j int) bool {
-						return pendingWrites[i].offset < pendingWrites[j].offset
-					})
-					break
-				}
-
-				// if we successfully wrote, then lets try the pending chunks
-				var removedOffsets map[int64]bool
-				for _, c := range pendingWrites {
-					successfullyWrote := s.writeChunkIfNeeded(doneWriting, c)
-					if !successfullyWrote {
-						break
-					}
-					removedOffsets[c.offset] = true
-				}
-
-				// remove the pending chunks that we successfully processed
-				newPendingWrites := make([]*toWriteChunk, 0, len(pendingWrites)-len(removedOffsets))
-				for _, c := range pendingWrites {
-					if removedOffsets[c.offset] {
-						continue
-					}
-					newPendingWrites = append(pendingWrites, c)
-				}
-				pendingWrites = newPendingWrites
-			}
-		}
-	}()
-
-	var latestChunk *byteChunk
-	var chunksBeingWritten int
-
 	for {
 		select {
 		case <-s.closed:
 			closedErr := errors.New("WriterAtStream Closed")
-			// set the error in case any more writes try to come in
-			s.err = closedErr
-			close(toWrite)
 
-			// wait for the writer to complete
-			wg.Wait()
-
-			close(doneWriting)
 			close(s.newChunks)
 
 			for chunk := range s.newChunks {
@@ -193,32 +70,37 @@ func (s *WriterAtStream) start() {
 			close(s.done)
 			return
 		case chunk := <-s.newChunks:
-			// copy to internal buffer
-			buf := s.bufferPool.Get()
-			copy(buf.Bytes(), chunk.bytes)
-
-			// since we have a new chunk, we can unblock the previous latest one. this is mainly
-			// just to prevent all of the WriteAts from continuing before the last write has occurred.
-			if latestChunk != nil {
-				latestChunk.response <- &writeAtResp{}
-				latestChunk = chunk
+			var err error
+			_, err = s.buffer.WriteAt(chunk.bytes, chunk.offset)
+			if err == ErrAfterBounds {
+				// this chunk is too far ahead, we need to block it being written for now
+				backedUp = append(backedUp, chunk)
+				continue
 			}
 
-			chunksBeingWritten++
+			for {
+				toWrite := s.buffer.Flush()
+				if len(toWrite) == 0 {
+					break
+				}
+				if _, err = s.writer.Write(toWrite); err != nil {
+					break
+				}
+				var newBackedUp []*byteChunk
+				for _, chunk := range backedUp {
+					if _, err = s.buffer.WriteAt(chunk.bytes, chunk.offset); err != nil {
+						if err == ErrAfterBounds {
+							newBackedUp = append(newBackedUp, chunk)
+							err = nil
+						} else {
+							break
+						}
+					}
+				}
+				backedUp = newBackedUp
+			}
 
-			writeChunk := &toWriteChunk{
-				buf:    buf,
-				offset: chunk.offset,
-			}
-			toWrite <- writeChunk
-		case chunk := <-doneWriting:
-			chunksBeingWritten--
-			s.bufferPool.Put(chunk.buf)
-			if latestChunk != nil && chunksBeingWritten == 0 {
-				// finished writing the latest chunk, unblock the write on it
-				latestChunk.response <- &writeAtResp{}
-				latestChunk = nil
-			}
+			chunk.response <- &writeAtResp{err}
 		}
 	}
 }
@@ -231,33 +113,6 @@ func (s *WriterAtStream) Close() {
 
 // WriteAt implements the io.WriterAt interface
 func (s *WriterAtStream) WriteAt(p []byte, off int64) (n int, err error) {
-	if off%int64(s.bufferSize) != 0 {
-		// this this writerAtStream expects to only received blocks of exactly the buffersize
-		// due to optimizations in the implementation.
-		return 0, fmt.Errorf("unexpected offset %q not multiple of %q", off, s.bufferSize)
-	}
-
-	for {
-		if s.err != nil {
-			return 0, s.err
-		}
-
-		s.offsetLock.RLock()
-		lastWrittenOffset := s.lastWrittenOffset
-		s.offsetLock.RUnlock()
-
-		// if we are attempting to write too far ahead in the buffer, then block and try again in a bit.
-		// this will put backpressure on threads that are too far ahead for our "streaming buffer".
-		allowedOffsetRange := s.bufferSize * s.bufferSize
-		if off > lastWrittenOffset+int64(allowedOffsetRange) {
-			time.Sleep(time.Nanosecond * 10)
-			continue
-		}
-		break
-	}
-
-	// we're good to try and write
-
 	response := make(chan *writeAtResp)
 	defer close(response)
 
@@ -268,7 +123,6 @@ func (s *WriterAtStream) WriteAt(p []byte, off int64) (n int, err error) {
 	}
 	s.newChunks <- chunk
 
-	// this response will block until either this write is completed or another write comes in after this one
 	r := <-response
 	return len(p), r.err
 }

--- a/s3stream_test.go
+++ b/s3stream_test.go
@@ -2,7 +2,11 @@ package iostream_test
 
 import (
 	"bytes"
+	"errors"
+	"math/rand"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/PullRequestInc/iostream"
 	"github.com/stretchr/testify/assert"
@@ -11,13 +15,179 @@ import (
 func TestS3SingleChunkSingleBuffer(t *testing.T) {
 	writer := new(bytes.Buffer)
 	numBuffers := 1
-	bufSize := 100
+	bufSize := 10
 	pool := iostream.NewBufPool(bufSize)
 
 	stream := iostream.OpenS3WriterAtStream(writer, pool, numBuffers, bufSize)
+	defer stream.Close()
 	written, err := stream.WriteAt([]byte("1234"), 0)
-	stream.Close()
 	assert.NoError(t, err)
 	assert.Equal(t, 4, written)
 	assert.Equal(t, "1234", writer.String())
+}
+
+func TestS3WritingNotMultipleOfBufSize(t *testing.T) {
+	writer := new(bytes.Buffer)
+	numBuffers := 1
+	bufSize := 10
+	pool := iostream.NewBufPool(bufSize)
+
+	stream := iostream.OpenS3WriterAtStream(writer, pool, numBuffers, bufSize)
+	defer stream.Close()
+	written, err := stream.WriteAt([]byte("1234"), 4)
+	assert.EqualError(t, err, "unexpected offset 4 not multiple of 10")
+	assert.Equal(t, 0, written)
+	assert.Equal(t, "", writer.String())
+}
+
+type errorWriter struct {
+	err error
+}
+
+func (ew *errorWriter) Write([]byte) (int, error) {
+	return 0, ew.err
+}
+
+func TestS3WritingFails(t *testing.T) {
+	// test with a writer that triggers a failure
+	err := errors.New("test failure")
+	writer := &errorWriter{err}
+	numBuffers := 1
+	bufSize := 10
+	pool := iostream.NewBufPool(bufSize)
+
+	stream := iostream.OpenS3WriterAtStream(writer, pool, numBuffers, bufSize)
+	defer stream.Close()
+	written, err := stream.WriteAt([]byte("1234"), 0)
+	assert.EqualError(t, err, "test failure")
+	assert.Equal(t, 0, written)
+}
+
+func TestS3WritingLargerThanBufferSize(t *testing.T) {
+	writer := new(bytes.Buffer)
+	numBuffers := 1
+	bufSize := 10
+	pool := iostream.NewBufPool(bufSize)
+
+	stream := iostream.OpenS3WriterAtStream(writer, pool, numBuffers, bufSize)
+	defer stream.Close()
+	written, err := stream.WriteAt([]byte("1234567890123"), 0)
+	assert.EqualError(t, err, "size of buffer being written 13 is greater than bufferSize 10")
+	assert.Equal(t, 0, written)
+	assert.Equal(t, "", writer.String())
+}
+
+func TestS3WriteSameOffsetTwiceErrors(t *testing.T) {
+	writer := new(bytes.Buffer)
+	numBuffers := 1
+	bufSize := 10
+	pool := iostream.NewBufPool(bufSize)
+
+	stream := iostream.OpenS3WriterAtStream(writer, pool, numBuffers, bufSize)
+	defer stream.Close()
+	written, err := stream.WriteAt([]byte("1234567890"), 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, written)
+	written, err = stream.WriteAt([]byte("55555"), 0)
+	assert.EqualError(t, err, "unexpectedly received same offset twice, 0")
+	assert.Equal(t, 0, written)
+}
+
+func TestS3WriteMultipleChunksInOrder(t *testing.T) {
+	writer := new(bytes.Buffer)
+	numBuffers := 1
+	bufSize := 10
+	pool := iostream.NewBufPool(bufSize)
+
+	stream := iostream.OpenS3WriterAtStream(writer, pool, numBuffers, bufSize)
+	defer stream.Close()
+	written, err := stream.WriteAt([]byte("1234567890"), 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, written)
+	written, err = stream.WriteAt([]byte("55555"), 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, written)
+	assert.Equal(t, "123456789055555", writer.String())
+}
+
+func TestS3WriteMultipleChunksOutOfOrder(t *testing.T) {
+	bufSize := 4
+	pool := iostream.NewBufPool(bufSize)
+
+	chunks := []string{
+		"1111",
+		"2222",
+		"3333",
+		"4444",
+		"5555",
+		"6666",
+		"7777",
+		"8888",
+		"9999",
+		"00",
+	}
+
+	run := func(numWorkers int) {
+		writer := new(bytes.Buffer)
+		stream := iostream.OpenS3WriterAtStream(writer, pool, numWorkers, bufSize)
+		defer stream.Close()
+
+		wg := sync.WaitGroup{}
+		wg.Add(numWorkers)
+
+		type block struct {
+			data   []byte
+			offset int64
+		}
+
+		ch := make(chan *block, numWorkers)
+
+		for i := 0; i < numWorkers; i++ {
+			go func() {
+				defer wg.Done()
+				for {
+					// wait for random amount of time to simulate requests taking different amounts of time
+					wait := rand.Intn(1000)
+					time.Sleep(time.Microsecond * time.Duration(wait))
+
+					select {
+					case blk := <-ch:
+						if blk == nil {
+							// we're done, no more blocks of data
+							return
+						}
+						written, err := stream.WriteAt(blk.data, blk.offset)
+						assert.NoError(t, err)
+						assert.Equal(t, len(blk.data), int(written))
+					}
+				}
+			}()
+		}
+
+		for i, chunk := range chunks {
+			b := &block{
+				data:   []byte(chunk),
+				offset: int64(i * bufSize),
+			}
+			ch <- b
+		}
+
+		close(ch)
+
+		wg.Wait()
+
+		assert.Equal(t, "11112222333344445555666677778888999900", writer.String())
+	}
+
+	// run with different worker numbers
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for numWorkers := 1; numWorkers < len(chunks)+1; numWorkers++ {
+				run(numWorkers)
+			}
+		}()
+	}
 }

--- a/s3stream_test.go
+++ b/s3stream_test.go
@@ -1,0 +1,23 @@
+package iostream_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PullRequestInc/iostream"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestS3SingleChunkSingleBuffer(t *testing.T) {
+	writer := new(bytes.Buffer)
+	numBuffers := 1
+	bufSize := 100
+	pool := iostream.NewBufPool(bufSize)
+
+	stream := iostream.OpenS3WriterAtStream(writer, pool, numBuffers, bufSize)
+	written, err := stream.WriteAt([]byte("1234"), 0)
+	stream.Close()
+	assert.NoError(t, err)
+	assert.Equal(t, 4, written)
+	assert.Equal(t, "1234", writer.String())
+}

--- a/s3stream_test.go
+++ b/s3stream_test.go
@@ -195,4 +195,5 @@ func TestS3WriteMultipleChunksOutOfOrder(t *testing.T) {
 			}
 		}()
 	}
+	wg.Wait()
 }


### PR DESCRIPTION
This adds a slightly "simplified" version of `WriterAtStream` that is more optimized for the usecase of being used with the s3 downloader.

It is still fairly complicated but I say its "simplified" because it isn't doing any of the stream buffer rotating buffer complication of the `WriterAtStream`. This one instead uses the same size buffers as the s3 downloader and assumes all chunks being written will be a full buffer of that size (or smaller if its the last chunk).

Other optimizations from this are that I added a `BufPool` which uses `sync.Pool` to allow us to recycle the buffers even between different `WriterAtStream`s over time to reduce the number of allocations needed. This also is much more non-blocking and doesn't block calls to `WriteAt` until they have been written. It only blocks in a few cases:
- while copying from the buffer passed to `WriteAt` to our own internal buffer (which is required since the caller may recycle their own buffers).
- if chunks too far in the future are attempted to be written.
- it blocks the most recent WriteAt until it completes or until a new WriteAt comes in. this is required so that when the Download call completes on the s3Manager, the content will have actually been fully downloaded.

I added some tests that simulate behavior of the s3 download manager with multiple workers pulling chunks off an ordered queue and writing them after random delays to simulate network and the "out of ordered-ness" that would occur. I ran these repeatedly with flags like `go test -race -count 1000 ./...` to suss out any race conditions/bugs I could.